### PR TITLE
Use Github Actions version 4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: styfle/cancel-workflow-action@0.9.1
 
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@2.19.0
@@ -34,7 +34,7 @@ jobs:
           composer-options: "--prefer-dist --classmap-authoritative"
 
       - name: phpstan-cache
-        uses: actions/cache@v3.0.3
+        uses: actions/cache@v4
         with:
           key: phpstan-${{ github.ref }}-${{ github.sha }}
           path: .phpstan-cache


### PR DESCRIPTION
See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/#what-you-need-to-do

This PR updates the uses of `actions/*` from `v3` to `v4`