### PR TITLE
fix: prevent new scheduled jobs from firing immediately on deploy

### DIFF
--- a/src/Cron/Schedule.php
+++ b/src/Cron/Schedule.php
@@ -91,13 +91,13 @@ final class Schedule
 
     public function isDue(?DateTimeInterface $lastTriggeredAt = null): bool
     {
-        if (Carbon::now()->subMinute() <= $lastTriggeredAt) {
+        if ($lastTriggeredAt !== null && Carbon::now()->subMinute() <= $lastTriggeredAt) {
             // CronExpression expects to be called only once per minute
             return false;
         }
 
         // last start time is before previous run date, possibly a missed chance to run the cron (worker off?)
-        if ($lastTriggeredAt < $this->cronExpression->getPreviousRunDate()) {
+        if ($lastTriggeredAt !== null && $lastTriggeredAt < $this->cronExpression->getPreviousRunDate()) {
             return true;
         }
 

--- a/tests/Cron/CronJobImplementationTest.php
+++ b/tests/Cron/CronJobImplementationTest.php
@@ -34,8 +34,24 @@ class CronJobImplementationTest extends TestCase
         $c = new class() extends ScheduleBasedCronJob {
             public function getSchedule(): Schedule
             {
-                $now = CarbonImmutable::now();
-                $tenMinutesLater = $now->addMinutes(10);
+                return Schedule::everyHour(CarbonImmutable::now()->minute);
+            }
+
+            public function run(?DateTimeInterface $lastStartedAt): void
+            {
+            }
+        };
+
+        // Job is due now but last triggered 2 hours ago — catch-up should fire
+        $this->assertTrue($c->shouldRun(CarbonImmutable::now()->subHours(2)));
+    }
+
+    public function testNewJobShouldNotRunWhenNotDue(): void
+    {
+        $c = new class() extends ScheduleBasedCronJob {
+            public function getSchedule(): Schedule
+            {
+                $tenMinutesLater = CarbonImmutable::now()->addMinutes(10);
 
                 return Schedule::everyHour($tenMinutesLater->minute);
             }
@@ -45,7 +61,8 @@ class CronJobImplementationTest extends TestCase
             }
         };
 
-        $this->assertTrue($c->shouldRun());
+        // New job (null lastTriggeredAt) that is NOT currently due should wait
+        $this->assertFalse($c->shouldRun());
     }
 
     public function testItShouldNotRun(): void

--- a/tests/Cron/ScheduleTest.php
+++ b/tests/Cron/ScheduleTest.php
@@ -50,13 +50,6 @@ class ScheduleTest extends TestCase
 
         $s = Schedule::everyMonth($now->day, $now->hour, $now->minute);
         $this->assertTrue($s->isDue($now->subMonth()));
-
-        $s = Schedule::everyHour($now->addMinutes(10)->minute);
-        $this->assertTrue($s->isDue());
-
-        $nextHour = $now->addHour();
-        $s = Schedule::everyDay($nextHour->hour, $nextHour->minute);
-        $this->assertTrue($s->isDue());
     }
 
     public function testItShouldNotBeDue(): void
@@ -74,6 +67,37 @@ class ScheduleTest extends TestCase
 
         $s = Schedule::everyMonth($nextDay->day, $nextDay->hour, $nextDay->minute);
         $this->assertFalse($s->isDue($nextDay->subMonth()));
+
+        // Jobs scheduled for the future should not be due even with no prior trigger
+        $s = Schedule::everyHour($tenMinutesLater->minute);
+        $this->assertFalse($s->isDue());
+
+        $nextHour = $now->addHour();
+        $s = Schedule::everyDay($nextHour->hour, $nextHour->minute);
+        $this->assertFalse($s->isDue());
+    }
+
+    public function testNewJobShouldNotFireImmediatelyWhenNotDue(): void
+    {
+        $now = CarbonImmutable::now();
+        $nextWeekday = $now->addWeekday();
+
+        // A weekly job scheduled for a different day should NOT fire when lastTriggeredAt is null (new job)
+        $s = Schedule::everyWeek($nextWeekday->dayOfWeek, $nextWeekday->hour, $nextWeekday->minute);
+        $this->assertFalse($s->isDue(null));
+        $this->assertFalse($s->isDue());
+    }
+
+    public function testNewJobShouldFireImmediatelyWhenDue(): void
+    {
+        $now = CarbonImmutable::now();
+
+        // A job that IS due right now should still fire even with null lastTriggeredAt
+        $s = Schedule::everyMinute();
+        $this->assertTrue($s->isDue(null));
+
+        $s = Schedule::everyDay($now->hour, $now->minute);
+        $this->assertTrue($s->isDue(null));
     }
 
     public function testItShouldNotBeDueTwice(): void


### PR DESCRIPTION
## Summary

- `Schedule::isDue()` treated `null` `lastTriggeredAt` (new job, no `cron_dates` entry) as a missed run because PHP evaluates `null < DateTime` to `true`
- This caused **every new scheduled job to fire immediately on deploy**, regardless of its cron expression
- New jobs now correctly wait for their first scheduled time

## Root cause

```php
// null < $this->cronExpression->getPreviousRunDate() -> always true in PHP
if ($lastTriggeredAt < $this->cronExpression->getPreviousRunDate()) {
    return true;
}
```

## Impact

This bug was latent since the initial commit (June 2022). It went unnoticed because:
- **Daily/hourly jobs**: firing on deploy is usually harmless (they would run that day anyway)
- **PostDeployment jobs**: have their own `shouldRun()` that intentionally fires on null
- **Weekly jobs**: first affected when added day-specific weekly job -- deploying on Friday caused Tuesday/Wednesday jobs to fire immediately

## Fix

Added `$lastTriggeredAt !== null` guard to both comparison branches. When `lastTriggeredAt` is null (new job), `isDue()` now falls through to `CronExpression::isDue(now)` -- which correctly checks if the current time matches the cron schedule.

## Test plan

- [x] All 37 tests passing
- [x] PHPStan clean
- [ ] Release as patch version (2.3.1)